### PR TITLE
Remove code duplication within views relating to the navbar.

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,10 @@
 module ApplicationHelper
+
+
+  def nav_link(path)
+    class_name = current_page?(path) ? "active" : ""
+    haml_tag(:li, class: class_name) do
+      yield
+    end
+  end
 end

--- a/app/views/doctrines/action.html.haml
+++ b/app/views/doctrines/action.html.haml
@@ -1,24 +1,3 @@
-%br
-%ul.nav.nav-pills
-  %li
-    %a{:href => "index"} Stoic Compass
-  %li
-    %a{:href => "about"} About
-  %li
-    %a{:href => "contact"} Contact
-  %li
-    %a{:href => "doctrines_index"} Doctrines
-  %li.active
-    %a{:href => "doctrines_action"} Doctrines - Discipline of Action
-  %li
-    %a{:href => "meditations"} Exercises
-  %li
-    %a{:href => "meditations"} Meditations
-
-%br
-%br
-
-%center
 .container
   .row
     .col-md-8

--- a/app/views/doctrines/assent.html.haml
+++ b/app/views/doctrines/assent.html.haml
@@ -1,24 +1,3 @@
-%br
-%ul.nav.nav-pills
-  %li
-    %a{:href => "index"} Stoic Compass
-  %li
-    %a{:href => "about"} About
-  %li
-    %a{:href => "contact"} Contact
-  %li
-    %a{:href => "doctrines_index"} Doctrines
-  %li.active
-    %a{:href => "doctrines_assent"} Doctrines - Discipline of Assent
-  %li
-    %a{:href => "meditations"} Exercises
-  %li
-    %a{:href => "meditations"} Meditations
-
-%br
-%br
-
-%center
 .container
   .row
     .col-md-8

--- a/app/views/doctrines/desire.html.haml
+++ b/app/views/doctrines/desire.html.haml
@@ -1,24 +1,3 @@
-%br
-%ul.nav.nav-pills
-  %li
-    %a{:href => "index"} Stoic Compass
-  %li
-    %a{:href => "about"} About
-  %li
-    %a{:href => "contact"} Contact
-  %li
-    %a{:href => "doctrines_index"} Doctrines
-  %li.active
-    %a{:href => "doctrines_desire"} Doctrines - Discipline of Desire
-  %li
-    %a{:href => "meditations"} Exercises
-  %li
-    %a{:href => "meditations"} Meditations
-
-%br
-%br
-
-%center
 .container
   .row
     .col-md-8

--- a/app/views/doctrines/disciplines_intro.html.haml
+++ b/app/views/doctrines/disciplines_intro.html.haml
@@ -1,24 +1,3 @@
-%br
-%ul.nav.nav-pills
-  %li
-    %a{:href => "index"} Stoic Compass
-  %li
-    %a{:href => "about"} About
-  %li
-    %a{:href => "contact"} Contact
-  %li
-    %a{:href => "doctrines_index"} Doctrines
-  %li.active
-    %a{:href => "doctrines_introduction"} Intro to Disciplines
-  %li
-    %a{:href => "meditations"} Exercises
-  %li
-    %a{:href => "meditations"} Meditations
-
-%br
-%br
-
-%center
 .container
   .row
     .col-md-8

--- a/app/views/doctrines/dogmas_intro.html.haml
+++ b/app/views/doctrines/dogmas_intro.html.haml
@@ -1,24 +1,3 @@
-%br
-%ul.nav.nav-pills
-  %li
-    %a{:href => "index"} Stoic Compass
-  %li
-    %a{:href => "about"} About
-  %li
-    %a{:href => "contact"} Contact
-  %li
-    %a{:href => "doctrines_index"} Doctrines
-  %li.active
-    %a{:href => "doctrines_action"} Doctrines - Intro to Dogmas
-  %li
-    %a{:href => "meditations"} Exercises
-  %li
-    %a{:href => "meditations"} Meditations
-
-%br
-%br
-
-%center
 .container
   .row
     .col-md-8

--- a/app/views/doctrines/index.html.haml
+++ b/app/views/doctrines/index.html.haml
@@ -1,20 +1,3 @@
-%br
-%ul.nav.nav-pills
-  %li
-    %a{:href => "index"} Stoic Compass
-  %li
-    %a{:href => "about"} About
-  %li
-    %a{:href => "contact"} Contact
-  %li.active
-    %a{:href => "doctrines_index"} Doctrines
-  %li
-    %a{:href => "meditations"} Exercises
-  %li
-    %a{:href => "meditations"} Meditations
-
-
-%center
 .container
   .row
     .col-md-8

--- a/app/views/doctrines/introduction.html.haml
+++ b/app/views/doctrines/introduction.html.haml
@@ -1,24 +1,3 @@
-%br
-%ul.nav.nav-pills
-  %li
-    %a{:href => "index"} Stoic Compass
-  %li
-    %a{:href => "about"} About
-  %li
-    %a{:href => "contact"} Contact
-  %li
-    %a{:href => "doctrines_index"} Doctrines
-  %li.active
-    %a{:href => "doctrines_introduction"} Doctrines Introduction
-  %li
-    %a{:href => "meditations"} Exercises
-  %li
-    %a{:href => "meditations"} Meditations
-
-%br
-%br
-
-%center
 .container
   .row
     .col-md-8

--- a/app/views/layouts/_navbar.html.haml
+++ b/app/views/layouts/_navbar.html.haml
@@ -1,0 +1,21 @@
+%nav.navbar.navbar-default
+  .navbar-header
+
+    =link_to "Stoic Compass", root_url, {class: "navbar-brand"}
+
+    %ul.nav.navbar-nav
+
+      - nav_link(about_path) do
+        = link_to "About", about_path
+      - nav_link(contact_path) do
+        = link_to "Contact", contact_path
+      - nav_link(doctrines_disciplines_intro_path) do
+        = link_to "Introduction to Stoicism", doctrines_disciplines_intro_path
+      - if (controller_name != "welcome")
+
+        - nav_link(doctrines_index_path) do
+          = link_to "Doctrines", doctrines_index_path
+
+        - nav_link(meditations_path) do
+          = link_to "Exercises", meditations_path
+

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -6,6 +6,14 @@
     = javascript_include_tag "application", "data-turbolinks-track" => true
     = csrf_meta_tags
   %body
+    = render partial: "layouts/navbar"
     = yield
+
+
+    %br/
+    %br/
+    %br/
+    %br/
+
     %center
       = image_tag "footer.png"

--- a/app/views/meditations/index.html.haml
+++ b/app/views/meditations/index.html.haml
@@ -1,17 +1,3 @@
-%ul.nav.nav-pills
-  %li
-    %a{:href => "index"} Stoic Compass
-  %li
-    %a{:href => "about"} About
-  %li
-    %a{:href => "contact"} Contact
-  %li
-    %a{:href => "doctrines_index"} Doctrines
-  %li
-    %a{:href => "meditations"} Exercises
-  %li.active
-    %a{:href => "meditations"} Meditations
-
 %h1 The Meditations of Marcus Aurelius
 
 %h4

--- a/app/views/welcome/about.html.haml
+++ b/app/views/welcome/about.html.haml
@@ -1,12 +1,3 @@
-%br
-%ul.nav.nav-pills
-  %li
-    %a{:href => "index"} Stoic Compass
-  %li.active
-    %a{:href => "about"} About
-  %li
-    %a{:href => "contact"} Contact
-
 %center
   .container
     .row
@@ -17,13 +8,3 @@
           %big An Application to Guide Stoic Philosophical Practice
         %br
           %p This web application - to which we intend to add a mobile app in the next 6 months - is to help us, our friends, and others we know to live out Stoic philosophical practice. It was created by Alessio Bona and Henry van Wagenberg. Made in Berlin. 2014-15.
-
-  %br
-  %br
-  %br
-  %br
-  %br
-  %br
-  %br
-  %br
-  %br

--- a/app/views/welcome/contact.html.haml
+++ b/app/views/welcome/contact.html.haml
@@ -1,13 +1,3 @@
-%br
-%ul.nav.nav-pills
-  %li
-    %a{:href => "index"} Stoic Compass
-  %li
-    %a{:href => "about"} About
-  %li.active
-    %a{:href => "contact"} Contact
-
-
 %center
   .container
     .row
@@ -22,11 +12,3 @@
           We are actively looking for feedback about our project, from users who would like to test it out.
 
           We live in Berlin, Germany. If you are interested in meeting us in person for coffee, we'd be happy to meet you.
-
-  %br
-  %br
-  %br
-  %br
-  %br
-  %br
-  %br

--- a/app/views/welcome/index.html.haml
+++ b/app/views/welcome/index.html.haml
@@ -1,14 +1,6 @@
-%br
-%ul.nav.nav-pills
-  %li.active
-    %a{:href => "index"} Stoic Compass
-  %li
-    %a{:href => "about"} About
-  %li
-    %a{:href => "contact"} Contact
 %center
   .page-header
-    %h3
+    %h2
       Marcus Aurelius' Compass
     %big An Application to Guide Stoic Philosophical Practice
 
@@ -16,28 +8,26 @@
   .container
     .row
       .col-sm-4
-        .thumbnail
-          = image_tag "doctrine.png"
-          .caption
-            %h5 Stoic Philosophy Explained
-            %p How did people in the ancient world understand philosophy? Read our description of the ideas behind Stoicism as a practice.
-          = button_to "The Stoic Doctrines", doctrines_index_path, method: :get, class: "btn btn-danger btn-large"
+        .panel.panel-default
+          .panel-body
+            = image_tag "doctrine.png"
+            .caption
+              %h5 Stoic Philosophy Explained
+              %p How did people in the ancient world understand philosophy? Read our description of the ideas behind Stoicism as a practice.
+            = button_to "The Stoic Doctrines", doctrines_index_path, method: :get, class: "btn btn-danger btn-large"
       .col-sm-4.col
-        .thumbnail
-          = image_tag "exercise.png"
-          .caption
-            %h5 Practice Stoic Exercises
-            %p How can you make Stoic philosophy into a lived practice? Run written and audio exercises we developed - and create your own.
-          = button_to "My Stoic Exercises", meditations_path, method: :get, class: "btn btn-warning btn-large"
+        .panel.panel-default
+          .panel-body
+            = image_tag "exercise.png"
+            .caption
+              %h5 Practice Stoic Exercises
+              %p How can you make Stoic philosophy into a lived practice? Run written and audio exercises we developed - and create your own.
+            = button_to "My Stoic Exercises", meditations_path, method: :get, class: "btn btn-warning btn-large"
       .col-sm-4.col
-        .thumbnail
-          = image_tag "meditation.png"
-          .caption
-            %h5 Read an Emperor's Meditations
-            %p Read meditations from Marcus Aurelius that we selected as inspirational and instructive for practicing Stoic philosophy today.
-          = button_to "Marcus Aurelius' Meditations", meditations_path, method: :get, class: "btn btn-primary btn-large"
-
-
-%br
-%br
-%br
+        .panel.panel-default
+          .panel-body
+            = image_tag "meditation.png"
+            .caption
+              %h5 Read an Emperor's Meditations
+              %p Read meditations from Marcus Aurelius that we selected as inspirational and instructive for practicing Stoic philosophy today.
+            = button_to "Marcus Aurelius' Meditations", meditations_path, method: :get, class: "btn btn-primary btn-large"


### PR DESCRIPTION
This commit does several things:
- Create a helper to determine which page we are on and display
  the active class in that li tag accordingly.
- Change the look of the navbar to be inline with the bootstrap navbar
  specs.
- Remove duplication of "navbars" in all pages where duplicated.
- Replace duplication with navbar partial in /layouts
- Move br/ from bottom of pages to layouts for uniformity.
- Change landing page from using a bootstrap thumbnail to a bootstrap
  panel
- Simplies navbar navigation but loses certain nav items, should be
  replaced/addressed in further commits
