### PR TITLE
Fix question adding / Cocoon insert

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -10,11 +10,11 @@
 // Read Sprockets README (https://github.com/sstephenson/sprockets#sprockets-directives) for details
 // about supported directives.
 //
-//= require turbolinks
 //= require jquery3
 //= require jquery_ujs
 //= require cocoon
 //= require popper
 //= require bootstrap-sprockets
+//= require turbolinks
 //= custom_js
 //= require_tree .

--- a/app/views/exercises/_form.html.haml
+++ b/app/views/exercises/_form.html.haml
@@ -6,8 +6,9 @@
   = f.file_field :icon, label: 'Add an image icon', class: 'form-control'
   %h3 Think-Exercise Questions
   = f.fields_for :questions do |question|
-    = render 'question_fields', f: question
-  = link_to_add_association 'Add New Question', f, :questions, class: 'btn btn-md btn-danger form-control mb-3'
+    = render 'question_fields', f: question, id: 'question'
+  .links
+    = link_to_add_association 'Add New Question', f, :questions, class: 'btn btn-md btn-danger form-control mb-3'
   %h5 At least one question is required in order to create a new exercise.
   %h5 There is a limit of 7 questions per exercise.
 

--- a/app/views/exercises/edit.html.haml
+++ b/app/views/exercises/edit.html.haml
@@ -1,7 +1,7 @@
 .container
   .row
     .col-md-8
-      .card.bg-info
+      .card.bg-dark
         .card-body
           .card-title
             %h1 Edit the exercise

--- a/app/views/exercises/new.html.haml
+++ b/app/views/exercises/new.html.haml
@@ -1,7 +1,7 @@
 .container
   .row
     .col-md-8
-      .card.bg-info
+      .card.bg-dark
         .card-body
           .card-title
             %h2 Create A New Exercise


### PR DESCRIPTION
Adding a question to the `Create Exercise` form was broken. The new question form input appeared at the top of the form AND it didn't even save that question.

Turns out I caused the problem by removing the `.link` class around the add button. The `Cocoon` `link_to_add_assocation` form helper needs that class in order to find where to insert the question. I think in order to see its relative position in the DOM, since it inserts based on `closest`, `parent` `child` depending on the attribute passed. More info: https://github.com/nathanvda/cocoon#link_to_add_association